### PR TITLE
Change all 'related' fields to the more appropriate 'upstream' field

### DIFF
--- a/vulns/commonmark/RSEC-2023-6.yaml
+++ b/vulns/commonmark/RSEC-2023-6.yaml
@@ -35,7 +35,7 @@ references:
   url: https://github.com/r-lib/commonmark/issues/13
 - type: WEB
   url: https://github.com/r-lib/commonmark/pull/18
-aliases:
+upstream:
 - CVE-2020-5238
-modified: "2023-10-20T07:27:00.600Z"
+modified: "2025-05-16T00:12:44Z"
 published: "2023-10-06T05:00:00.600Z"

--- a/vulns/commonmark/RSEC-2023-7.yaml
+++ b/vulns/commonmark/RSEC-2023-7.yaml
@@ -36,8 +36,8 @@ references:
   url: https://security-tracker.debian.org/tracker/CVE-2022-24724
 - type: WEB
   url: https://github.com/r-lib/commonmark/pull/18
-aliases:
+upstream:
 - CVE-2022-39209
 - CVE-2022-24724
-modified: "2023-10-20T07:27:00.600Z"
+modified: "2025-05-16T00:12:44Z"
 published: "2023-10-06T05:00:00.600Z"

--- a/vulns/commonmark/RSEC-2023-8.yaml
+++ b/vulns/commonmark/RSEC-2023-8.yaml
@@ -50,7 +50,7 @@ references:
   url: https://security-tracker.debian.org/tracker/CVE-2023-22483
 - type: WEB
   url: https://github.com/r-lib/commonmark/issues/26
-aliases:
+upstream:
 - CVE-2023-37463
 - CVE-2023-26485
 - CVE-2023-24824
@@ -58,5 +58,5 @@ aliases:
 - CVE-2023-22485
 - CVE-2023-22484
 - CVE-2023-22483
-modified: "2023-10-20T07:27:00.600Z"
+modified: "2025-05-16T00:12:44Z"
 published: "2023-10-06T05:00:00.600Z"

--- a/vulns/gdata/RSEC-2023-9.yaml
+++ b/vulns/gdata/RSEC-2023-9.yaml
@@ -24,7 +24,7 @@ references:
   url: https://security-tracker.debian.org/tracker/CVE-2023-7101
 - type: WEB
   url: https://github.com/r-gregmisc/gdata/issues/14
-aliases:
+upstream:
 - CVE-2023-7101
-published: "2023-12-28T02:15:00.000Z"
+published: "2025-05-16T00:12:44Z"
 modified: "2024-01-04T02:15:00.000Z"

--- a/vulns/haven/RSEC-2023-5.yaml
+++ b/vulns/haven/RSEC-2023-5.yaml
@@ -31,9 +31,9 @@ references:
   url: https://github.com/WizardMac/ReadStat/issues/108
 - type: WEB
   url: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=899335
-aliases:
+upstream:
 - CVE-2018-11365
 - CVE-2018-11364
 - CVE-2018-5698
-modified: "2023-10-20T07:27:00.600Z"
+modified: "2025-05-16T00:12:44Z"
 published: "2023-10-05T05:00:00.600Z"

--- a/vulns/igraph/RSEC-2023-4.yaml
+++ b/vulns/igraph/RSEC-2023-4.yaml
@@ -26,7 +26,7 @@ references:
   url: https://github.com/igraph/igraph/issues/1141
 - type: WEB
   url: https://security-tracker.debian.org/tracker/CVE-2018-20349
-aliases:
+upstream:
 - CVE-2018-20349
-modified: "2023-10-20T07:27:00.600Z"
+modified: "2025-05-16T00:12:44Z"
 published: "2023-10-04T03:23:51.600Z"

--- a/vulns/jsonlite/RSEC-2023-3.yaml
+++ b/vulns/jsonlite/RSEC-2023-3.yaml
@@ -56,7 +56,7 @@ references:
   url: https://lists.debian.org/debian-lts-announce/2023/07/msg00013.html
 - type: WEB
   url: https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KLE3C4CECEJ4EUYI56KXI6OWACWXX7WN/
-aliases:
+upstream:
 - CVE-2023-33460
-modified: "2023-10-20T07:27:00.600Z"
+modified: "2025-05-16T00:12:44Z"
 published: "2023-07-18T04:37:21.600Z"

--- a/vulns/readxl/RSEC-2023-0.yaml
+++ b/vulns/readxl/RSEC-2023-0.yaml
@@ -47,7 +47,7 @@ references:
   url: https://www.talosintelligence.com/vulnerability_reports/TALOS-2017-0463
 - type: WEB
   url: https://github.com/evanmiller/libxls/issues/34
-aliases:
+upstream:
 - CVE-2017-2896
 - CVE-2017-2897
 - CVE-2017-2919
@@ -55,5 +55,5 @@ aliases:
 - CVE-2017-12109
 - CVE-2017-12110
 - CVE-2017-12111
-modified: "2023-10-19T01:17:00.600Z"
+modified: "2025-05-16T00:12:44Z"
 published: "2023-07-13T02:22:58.600Z"

--- a/vulns/readxl/RSEC-2023-1.yaml
+++ b/vulns/readxl/RSEC-2023-1.yaml
@@ -32,8 +32,8 @@ references:
   url: https://github.com/evanmiller/libxls/issues/34
 - type: WEB
   url: https://github.com/evanmiller/libxls/issues/35
-aliases:
+upstream:
 - CVE-2018-20450
 - CVE-2018-20452
-modified: "2023-10-20T07:27:00.600Z"
+modified: "2025-05-16T00:12:44Z"
 published: "2023-07-13T02:37:06.600Z"

--- a/vulns/readxl/RSEC-2023-2.yaml
+++ b/vulns/readxl/RSEC-2023-2.yaml
@@ -24,7 +24,7 @@ references:
   url: https://security-tracker.debian.org/tracker/source-package/r-cran-readxl
 - type: WEB
   url: https://nvd.nist.gov/vuln/detail/CVE-2021-27836
-aliases:
+upstream:
 - CVE-2021-27836
-modified: "2023-10-20T07:27:00.600Z"
+modified: "2025-05-16T00:12:44Z"
 published: "2023-07-13T02:46:57.600Z"


### PR DESCRIPTION
Fixes https://github.com/RConsortium/r-advisory-database/issues/9. Switches all `related` fields to the more appropriate `upstream` field, https://ossf.github.io/osv-schema/#upstream-field